### PR TITLE
refactor: extract reusable products header

### DIFF
--- a/app/products/[slug]/page.tsx
+++ b/app/products/[slug]/page.tsx
@@ -1,64 +1,11 @@
-import Link from "next/link"
-import { Home, Package, Activity } from "lucide-react"
-import Image from "next/image"
-import { CartButton } from "@/app/components/cart-button"
-import { MobileNav } from "@/app/components/mobile-nav"
-import { SearchButton } from "@/app/components/search-button";
+import { ProductsHeader } from "@/components/products-header"
 import { ProductPageClient } from "@/app/components/product-page-client"
 import { productSlugs } from "@/lib/product-slugs"
 
 export default function ProductPage({ params }: { params: { slug: string } }) {
   return (
     <div className="min-h-screen bg-theme-primary relative overflow-hidden">
-      <header className="h-16 flex items-center justify-between container mx-auto top-0 absolute inset-x-0 z-50 px-4 sm:px-6">
-        <div className="flex items-center space-x-8">
-          <Link href="/">
-            <Image
-              src="/kimera-logo.svg"
-              alt="Komerza"
-              width={138}
-              height={55}
-              className="h-8 sm:h-9 w-auto"
-            />
-          </Link>
-          <div className="items-center gap-4 hidden md:flex">
-            <Link
-              href="/"
-              className="text-theme-secondary hover:text-[#3B82F6] hover:bg-[#3B82F6]/10 flex items-center gap-2 rounded-md bg-transparent px-2.5 py-1.5 transition-colors duration-300"
-            >
-              <Home className="w-[18px] h-[18px]" />
-              <span className="text-sm font-normal tracking-20-smaller">
-                Home
-              </span>
-            </Link>
-            <Link
-              href="/products"
-              className="text-[#3B82F6] hover:text-[#3B82F6] hover:bg-[#3B82F6]/10 flex items-center gap-2 rounded-md bg-[#3B82F6]/10 px-2.5 py-1.5 transition-colors duration-300"
-            >
-              <Package className="w-[18px] h-[18px]" />
-              <span className="text-sm font-normal tracking-20-smaller">
-                Products
-              </span>
-            </Link>
-            <Link
-              href="/status"
-              className="text-theme-secondary hover:text-[#3B82F6] hover:bg-[#3B82F6]/10 flex items-center gap-2 rounded-md bg-transparent px-2.5 py-1.5 transition-colors duration-300"
-            >
-              <Activity className="w-[18px] h-[18px]" />
-              <span className="text-sm font-normal tracking-20-smaller">
-                Status
-              </span>
-            </Link>
-          </div>
-        </div>
-        <div className="flex items-center gap-4">
-          <SearchButton />
-          <div className="hidden md:flex items-center gap-4">
-            <CartButton />
-          </div>
-          <MobileNav />
-        </div>
-      </header>
+      <ProductsHeader />
       <main className="container mx-auto pt-24 px-4 sm:px-6">
         <ProductPageClient slug={params.slug} />
       </main>

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -1,63 +1,10 @@
-import Link from "next/link"
-import { Home, Package, Activity } from "lucide-react"
-import Image from "next/image"
-import { CartButton } from "@/app/components/cart-button"
-import { MobileNav } from "@/app/components/mobile-nav"
-import { SearchButton } from "@/app/components/search-button"
+import { ProductsHeader } from "@/components/products-header"
 import { ProductsPageClient } from "@/app/components/products-page-client"
 
 export default function ProductsPage() {
   return (
     <div className="min-h-screen bg-theme-primary relative overflow-hidden">
-      <header className="h-16 flex items-center justify-between container mx-auto top-0 absolute inset-x-0 z-50 px-4 sm:px-6">
-        <div className="flex items-center space-x-8">
-          <Link href="/">
-            <Image
-              src="/kimera-logo.svg"
-              alt="Komerza"
-              width={138}
-              height={55}
-              className="h-8 sm:h-9 w-auto"
-            />
-          </Link>
-          <div className="items-center gap-4 hidden md:flex">
-            <Link
-              href="/"
-              className="text-theme-secondary hover:text-[#3B82F6] hover:bg-[#3B82F6]/10 flex items-center gap-2 rounded-md bg-transparent px-2.5 py-1.5 transition-colors duration-300"
-            >
-              <Home className="w-[18px] h-[18px]" />
-              <span className="text-sm font-normal tracking-20-smaller">
-                Home
-              </span>
-            </Link>
-            <Link
-              href="/products"
-              className="text-[#3B82F6] hover:text-[#3B82F6] hover:bg-[#3B82F6]/10 flex items-center gap-2 rounded-md bg-[#3B82F6]/10 px-2.5 py-1.5 transition-colors duration-300"
-            >
-              <Package className="w-[18px] h-[18px]" />
-              <span className="text-sm font-normal tracking-20-smaller">
-                Products
-              </span>
-            </Link>
-            <Link
-              href="/status"
-              className="text-theme-secondary hover:text-[#3B82F6] hover:bg-[#3B82F6]/10 flex items-center gap-2 rounded-md bg-transparent px-2.5 py-1.5 transition-colors duration-300"
-            >
-              <Activity className="w-[18px] h-[18px]" />
-              <span className="text-sm font-normal tracking-20-smaller">
-                Status
-              </span>
-            </Link>
-          </div>
-        </div>
-        <div className="flex items-center gap-4">
-          <SearchButton />
-          <div className="hidden md:flex items-center gap-4">
-            <CartButton />
-          </div>
-          <MobileNav />
-        </div>
-      </header>
+      <ProductsHeader />
       <main className="container mx-auto pt-24 px-4 sm:px-6">
         <ProductsPageClient />
       </main>

--- a/components/products-header.tsx
+++ b/components/products-header.tsx
@@ -1,0 +1,60 @@
+import Link from "next/link"
+import Image from "next/image"
+import { Home, Package, Activity } from "lucide-react"
+import { CartButton } from "@/app/components/cart-button"
+import { MobileNav } from "@/app/components/mobile-nav"
+import { SearchButton } from "@/app/components/search-button"
+
+export function ProductsHeader() {
+  return (
+    <header className="h-16 flex items-center justify-between container mx-auto top-0 absolute inset-x-0 z-50 px-4 sm:px-6">
+      <div className="flex items-center space-x-8">
+        <Link href="/">
+          <Image
+            src="/kimera-logo.svg"
+            alt="Komerza"
+            width={138}
+            height={55}
+            className="h-8 sm:h-9 w-auto"
+          />
+        </Link>
+        <div className="items-center gap-4 hidden md:flex">
+          <Link
+            href="/"
+            className="text-theme-secondary hover:text-[#3B82F6] hover:bg-[#3B82F6]/10 flex items-center gap-2 rounded-md bg-transparent px-2.5 py-1.5 transition-colors duration-300"
+          >
+            <Home className="w-[18px] h-[18px]" />
+            <span className="text-sm font-normal tracking-20-smaller">
+              Home
+            </span>
+          </Link>
+          <Link
+            href="/products"
+            className="text-[#3B82F6] hover:text-[#3B82F6] hover:bg-[#3B82F6]/10 flex items-center gap-2 rounded-md bg-[#3B82F6]/10 px-2.5 py-1.5 transition-colors duration-300"
+          >
+            <Package className="w-[18px] h-[18px]" />
+            <span className="text-sm font-normal tracking-20-smaller">
+              Products
+            </span>
+          </Link>
+          <Link
+            href="/status"
+            className="text-theme-secondary hover:text-[#3B82F6] hover:bg-[#3B82F6]/10 flex items-center gap-2 rounded-md bg-transparent px-2.5 py-1.5 transition-colors duration-300"
+          >
+            <Activity className="w-[18px] h-[18px]" />
+            <span className="text-sm font-normal tracking-20-smaller">
+              Status
+            </span>
+          </Link>
+        </div>
+      </div>
+      <div className="flex items-center gap-4">
+        <SearchButton />
+        <div className="hidden md:flex items-center gap-4">
+          <CartButton />
+        </div>
+        <MobileNav />
+      </div>
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary
- extract shared products header into `ProductsHeader`
- replace duplicated headers in product pages with `ProductsHeader`

## Testing
- `npm test` *(fails: Missing script "test"*
- `npm run lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_689f521f9d20832395bbb8d55e9255e7