### PR TITLE
feat: load Komerza script via provider

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,24 +6,6 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
-    <script src="https://cdn.komerza.com/komerza.min.js"></script>
-    <script>
-      function initKomerza() {
-        if (typeof globalThis.komerza !== 'undefined') {
-          globalThis.komerza.init("7c1e4aa4-a28f-4855-a7e1-6dcc020d2083");
-        } else {
-          setTimeout(initKomerza, 100);
-        }
-      }
-      document.documentElement.classList.add('dark');
-      document.documentElement.classList.remove('light');
-      localStorage.setItem('theme', 'dark');
-      if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', initKomerza);
-      } else {
-        initKomerza();
-      }
-    </script>
     <title>Komerza Astra</title>
   </head>
   <body>

--- a/src/KomerzaProvider.tsx
+++ b/src/KomerzaProvider.tsx
@@ -1,0 +1,52 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import { loadKomerza } from "@/lib/komerza-loader";
+import { KOMERZA_STORE_ID } from "@/lib/komerza";
+
+interface KomerzaState {
+  ready: boolean;
+  error: Error | null;
+}
+
+const KomerzaContext = createContext<KomerzaState>({ ready: false, error: null });
+
+export function useKomerzaState() {
+  return useContext(KomerzaContext);
+}
+
+export function KomerzaProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<KomerzaState>({ ready: false, error: null });
+
+  useEffect(() => {
+    loadKomerza()
+      .then(() => {
+        try {
+          globalThis.komerza?.init?.(KOMERZA_STORE_ID);
+          setState({ ready: true, error: null });
+        } catch (err) {
+          const error = err instanceof Error ? err : new Error(String(err));
+          setState({ ready: false, error });
+        }
+      })
+      .catch((err) => {
+        const error = err instanceof Error ? err : new Error(String(err));
+        setState({ ready: false, error });
+      });
+  }, []);
+
+  useEffect(() => {
+    if (state.ready) {
+      setTimeout(() => document.dispatchEvent(new Event("komerza:ready")), 0);
+    } else if (state.error) {
+      setTimeout(
+        () => document.dispatchEvent(new CustomEvent("komerza:load-error", { detail: state.error })),
+        0
+      );
+    }
+  }, [state.ready, state.error]);
+
+  if (!state.ready) {
+    return null;
+  }
+
+  return <KomerzaContext.Provider value={state}>{children}</KomerzaContext.Provider>;
+}

--- a/src/lib/komerza-loader.ts
+++ b/src/lib/komerza-loader.ts
@@ -1,0 +1,23 @@
+export function loadKomerza(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (typeof globalThis.komerza !== "undefined") {
+      resolve();
+      return;
+    }
+
+    const existing = document.querySelector<HTMLScriptElement>("script[data-komerza]");
+    if (existing) {
+      existing.addEventListener("load", () => resolve(), { once: true });
+      existing.addEventListener("error", () => reject(new Error("Failed to load Komerza script")), { once: true });
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = "https://cdn.komerza.com/komerza.min.js";
+    script.async = true;
+    script.dataset.komerza = "true";
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error("Failed to load Komerza script"));
+    document.head.appendChild(script);
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,12 +4,15 @@ import App from './App';
 import './index.css';
 import { CartProvider } from './context/cart-context';
 import { Toaster } from 'sonner';
+import { KomerzaProvider } from './KomerzaProvider';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <CartProvider>
-      <App />
-      <Toaster />
-    </CartProvider>
-  </React.StrictMode>
+    <KomerzaProvider>
+      <CartProvider>
+        <App />
+        <Toaster />
+      </CartProvider>
+    </KomerzaProvider>
+  </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- dynamically load Komerza script via new `loadKomerza` helper
- add `KomerzaProvider` to initialize Komerza and dispatch ready/error events
- mount provider at app root and remove inline script from `index.html`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5715f68e8832386d8281a137e3448