### PR TITLE
Refactor mobile navigation state management

### DIFF
--- a/src/components/mobile-nav.tsx
+++ b/src/components/mobile-nav.tsx
@@ -1,61 +1,28 @@
 "use client"
 
-import { useState } from "react";
-import { Menu, X, LayoutDashboard } from "lucide-react";
+import { LayoutDashboard } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Link } from "react-router-dom";
-import { CartButton } from "./cart-button";
 import { navLinks } from "./nav-links";
 import { cn } from "@/lib/utils";
 
 interface MobileNavProps {
-  isOpen?: boolean;
-  onClose?: () => void;
+  isOpen: boolean;
+  onClose: () => void;
 }
 
-export function MobileNav({
-  isOpen: externalIsOpen,
-  onClose: externalOnClose,
-}: MobileNavProps = {}) {
-  const [internalIsOpen, setInternalIsOpen] = useState(false);
-
-  // Use external state if provided, otherwise use internal state
-  const isOpen = externalIsOpen !== undefined ? externalIsOpen : internalIsOpen;
-  const setIsOpen =
-    externalOnClose !== undefined
-      ? (value: boolean) => {
-          if (!value) externalOnClose();
-        }
-      : setInternalIsOpen;
-
-  const toggleMenu = () => setIsOpen(!isOpen);
-  const closeMenu = () => setIsOpen(false);
-
+export function MobileNav({ isOpen, onClose }: MobileNavProps) {
   const mobileNavLinkClass =
     "flex items-center gap-3 rounded-md px-4 py-3 transition-colors duration-300 mobile-touch-target text-theme-secondary hover:text-[#3B82F6] hover:bg-white/15";
 
   return (
     <>
-      {/* Mobile Menu Button - only show if we're managing our own state */}
-      {externalIsOpen === undefined && (
-        <div className="md:hidden flex items-center gap-1">
-          <CartButton />
-          <Button
-            onClick={toggleMenu}
-            className="bg-transparent border border-theme text-theme-primary hover:bg-theme-secondary h-8 w-8 p-0 rounded-md transition-all duration-300"
-          >
-            {isOpen ? <X className="w-4 h-4" /> : <Menu className="w-4 h-4" />}
-          </Button>
-        </div>
-      )}
-
-      {/* Mobile Menu Overlay */}
       {isOpen && (
         <>
           {/* Backdrop */}
           <div
             className="fixed top-16 left-0 right-0 bottom-0 bg-black/60 backdrop-blur-sm z-40 md:hidden"
-            onClick={closeMenu}
+            onClick={onClose}
           />
 
           {/* Mobile Menu */}
@@ -68,7 +35,7 @@ export function MobileNav({
                     <Link
                       key={link.href}
                       to={link.href}
-                      onClick={closeMenu}
+                      onClick={onClose}
                       className={cn(
                         mobileNavLinkClass,
                         link.href === "/" &&
@@ -82,7 +49,7 @@ export function MobileNav({
                     </Link>
                   ))}
                 <div className="pt-4 border-t border-theme">
-                  <Link to="/dashboard" onClick={closeMenu}>
+                  <Link to="/dashboard" onClick={onClose}>
                     <Button className="w-full bg-[#3B82F6] text-white hover:bg-[#2563EB] h-12 px-4 py-3 rounded-md flex items-center justify-center gap-3 text-base tracking-20-smaller transition-all duration-300 font-normal mobile-touch-target">
                       <LayoutDashboard className="w-5 h-5" />
                       <span>Client Area</span>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
-import { UserPlus, Menu } from "lucide-react";
+import { UserPlus, Menu, X } from "lucide-react";
 import { SearchButton } from "./search-button";
 import { CartButton } from "./cart-button";
 import { MobileNav } from "./mobile-nav";
@@ -74,10 +74,10 @@ export function Navbar() {
             </Link>
             {/* Mobile Menu Button */}
             <button
-              onClick={() => setIsMobileNavOpen(true)}
+              onClick={() => setIsMobileNavOpen((prev) => !prev)}
               className="duration-200 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-8 py-2 block sm:hidden px-2"
             >
-              <Menu size={14} />
+              {isMobileNavOpen ? <X size={14} /> : <Menu size={14} />}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Simplify `MobileNav` to accept only `isOpen` and `onClose` props and remove internal toggle button
- Let `Navbar` manage the mobile menu state and toggle between menu and close icons

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b5a1246d848323a5313881eaf7c1d9